### PR TITLE
cc mentorship carousel no-animate d8-2529

### DIFF
--- a/templates/views-view-unformatted--mentorship_facet_search--block_1.html.twig
+++ b/templates/views-view-unformatted--mentorship_facet_search--block_1.html.twig
@@ -18,7 +18,7 @@
  */
 #}
 
-<div id="mentor-slider" class="carousel slide container" data-ride="carousel">
+<div id="mentor-slider" class="carousel container">
   <div class="carousel-inner row ml-1">
 	{% for row in rows %}
 		{%


### PR DESCRIPTION
## Describe context / purpose for this PR
Campus Champions make carousel not animate
## Issue link
https://cyberteamportal.atlassian.net/browse/D8-2529
## Any other related PRs?
- https://github.com/necyberteam/cyberteam_drupal/pull/1626
## Link to MultiDev instance
http://md-2529-accessmatch.pantheonsite.io